### PR TITLE
Add compatibility for PK's Creative Super flat dimension

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,8 @@
 plugins {
-	id 'fabric-loom' version '1.6-SNAPSHOT'
+	id 'fabric-loom' version '1.7-SNAPSHOT'
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_21
-targetCompatibility = JavaVersion.VERSION_21
-
-archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
 
@@ -37,7 +33,6 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	// Minecraft 1.18 (1.18-pre2) upwards uses Java 17.
 	it.options.release = 21
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,6 @@ loader_version=0.15.11
 fabric_version=0.100.3+1.21
 
 # Mod Properties
-	mod_version = 1.6.3
+	mod_version = 1.6.4
 	maven_group = me.glitch.aitecraft
 	archives_base_name = shareenderchest

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/me/glitch/aitecraft/shareenderchest/util/Compat.java
+++ b/src/main/java/me/glitch/aitecraft/shareenderchest/util/Compat.java
@@ -1,0 +1,14 @@
+package me.glitch.aitecraft.shareenderchest.util;
+
+import net.minecraft.registry.RegistryKey;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.World;
+
+public final class Compat {
+
+    private Compat() { throw new AssertionError(); }
+
+    public static final RegistryKey<World> CREATIVE_SUPERFLAT_KEY = RegistryKey.of(RegistryKeys.WORLD, Identifier.of("pk_cr_di", "creative_superflat"));
+
+}

--- a/src/main/java/me/glitch/aitecraft/shareenderchest/util/SharedInvAccessType.java
+++ b/src/main/java/me/glitch/aitecraft/shareenderchest/util/SharedInvAccessType.java
@@ -1,0 +1,23 @@
+package me.glitch.aitecraft.shareenderchest.util;
+
+import net.minecraft.entity.player.PlayerEntity;
+
+public enum SharedInvAccessType {
+    ITEM_USE,
+    BLOCK_USE,
+    SLOT_USE;
+
+    public boolean shouldPlayerUseItem(PlayerEntity player) {
+        boolean isInCreativeDim = player.getWorld().getRegistryKey().equals(Compat.CREATIVE_SUPERFLAT_KEY);
+        if (isInCreativeDim) {
+            return false;
+        }
+        return switch (this) {
+            case ITEM_USE -> !player.isSpectator();
+            case BLOCK_USE -> !player.isSpectator() && player.isSneaking();
+            case SLOT_USE -> true;
+        };
+
+    }
+
+}


### PR DESCRIPTION
This pull request adds support for Kawamood's [Creative Dimension](https://modrinth.com/datapack/creative-dimension) datapack. More specifically, it checks whether the player is in the creative dimension before attempting to open the shared inventory, in which case it won't open the shared inventory.

This PR can be merged as is, but I am willing to expand on this PR by adding a configuration system that lets admins use a whitelist or a blacklist to configure dimensions where players are allowed to use the shared inventory. However, I plan to do this using my own [configuration library](https://github.com/ArkoSammy12/Monkey-Config), which depends on Fabric Language Kotlin and Fabric API. I would like to ask if you would be ok with your mod having these extra dependencies so that I can go ahead and implement the configuration system. Otherwise, this PR should be enough.