### PR TITLE
feat: add config file for most hard-coded values

### DIFF
--- a/src/main/java/me/glitch/aitecraft/shareenderchest/SharedInventory.java
+++ b/src/main/java/me/glitch/aitecraft/shareenderchest/SharedInventory.java
@@ -9,12 +9,11 @@ import net.minecraft.util.collection.DefaultedList;
 import java.util.Iterator;
 
 public class SharedInventory implements Inventory {
-    public static final int SECTION_SIZE = 54;
     private final DefaultedList<ItemStack> stacks;
     //private static final HashMap<PlayerEntity, EnderChestBlockEntity> enderChests = new HashMap<PlayerEntity, EnderChestBlockEntity>();
 
-    public SharedInventory() {
-        this.stacks = DefaultedList.ofSize(SECTION_SIZE, ItemStack.EMPTY);
+    public SharedInventory(int inventoryRows) {
+        this.stacks = DefaultedList.ofSize(inventoryRows * 9, ItemStack.EMPTY);
     }
 
     public SharedInventory(DefaultedList<ItemStack> dl) {

--- a/src/main/java/me/glitch/aitecraft/shareenderchest/config/Config.java
+++ b/src/main/java/me/glitch/aitecraft/shareenderchest/config/Config.java
@@ -1,0 +1,25 @@
+package me.glitch.aitecraft.shareenderchest.config;
+
+import net.minecraft.screen.GenericContainerScreenHandler;
+import net.minecraft.screen.ScreenHandlerType;
+
+public class Config {
+    public long autosaveSeconds = 300;
+    public boolean requireSneak = true;
+    public int inventoryRows = 6;
+    public boolean openFromHand = true;
+    public boolean playOpenSound = false;
+    public String inventoryName = "Shared Ender Chest";
+
+    public ScreenHandlerType<GenericContainerScreenHandler> screenHandlerType() {
+        return switch (inventoryRows) {
+            case 1 -> ScreenHandlerType.GENERIC_9X1;
+            case 2 -> ScreenHandlerType.GENERIC_9X2;
+            case 3 -> ScreenHandlerType.GENERIC_9X3;
+            case 4 -> ScreenHandlerType.GENERIC_9X4;
+            case 5 -> ScreenHandlerType.GENERIC_9X5;
+            case 6 -> ScreenHandlerType.GENERIC_9X6;
+            default -> ScreenHandlerType.GENERIC_9X3;
+        };
+    }
+}

--- a/src/main/java/me/glitch/aitecraft/shareenderchest/config/ConfigManager.java
+++ b/src/main/java/me/glitch/aitecraft/shareenderchest/config/ConfigManager.java
@@ -1,0 +1,33 @@
+package me.glitch.aitecraft.shareenderchest.config;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import net.fabricmc.loader.api.FabricLoader;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+
+public class ConfigManager {
+    private static final File CONFIG_FILE = FabricLoader.getInstance().getConfigDir().resolve("share-ender-chest.json").toFile();
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+    public static Config load() {
+        try (FileReader reader = new FileReader(CONFIG_FILE)) {
+            return GSON.fromJson(reader, Config.class);
+        } catch (IOException e) {
+            Config config = new Config();
+            save(config);
+            return config;
+        }
+    }
+
+    public static void save(Config config) {
+        try (FileWriter writer = new FileWriter(CONFIG_FILE)) {
+            GSON.toJson(config, writer);
+        } catch (IOException e) {
+            System.out.println("Error saving config: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Added a simple json config file for:

- `autosaveSeconds` - interval to autosave the chest contents
- `requireSneak` - if the shared chest should be opened only when sneaking (or all the time)
- `inventoryRows` - number of inventory rows in the shared chest (1-6)
- `openInHand` - allow opening ender chest from the player's hand without placing it down
- `playOpenSound` - play the ender chest opening sound
- `inventoryName` - the name of the shared ender chest displayed in the ui

The default values should result in no changes in behaviour from the previous version.
I haven't touched any of the mod metadata as I was unsure about your versioning scheme.